### PR TITLE
Show the correct number of documents in an eprint

### DIFF
--- a/citations/eprint/latest_additions_result.xml
+++ b/citations/eprint/latest_additions_result.xml
@@ -5,18 +5,20 @@
 			<if test="length($docs) gt 0">
 				<div class="ep_citation_tile_result_docs">
 					<foreach expr="$docs" iterator="doc" limit="1">
-						<if test="$doc.is_public()"> 
-						<a href="{$item.uri()}">
-							<img src="{$doc.thumbnail_url('lightbox')}"/>
-							<div class="ep_citation_tile_result_docs ep_public_doc"></div>
-						</a>
- 						</if>
+						<if test="$doc.is_public()">
+							<a href="{$item.uri()}">
+								<div class="ep_citation_tile_result_docs ep_public_doc">
+									<if test="is_set($doc.thumbnail_url('lightbox'))">
+										<img src="{$doc.thumbnail_url('lightbox')}" />
+									</if>
+								</div>
+							</a>
+						</if>
 						<if test="!$doc.is_public()">
-						<a href="{$item.uri()}">
-							<img src=""/>
-							<div class="ep_citation_tile_result_docs ep_restricted_doc"></div>
-						</a>
-						</if> 
+							<a href="{$item.uri()}">
+								<div class="ep_citation_tile_result_docs ep_restricted_doc" />
+							</a>
+						</if>
 					</foreach>
 				</div>
 			</if>
@@ -30,7 +32,7 @@
 				</div>
 			</if>
 			<if test="length($docs) lt 1">
-				<div class="ep_citation_tile_result_docs ep_citation_tile_result_metadata_only"></div>
+				<div class="ep_citation_tile_result_docs ep_citation_tile_result_metadata_only" />
 			</if>
 		</set>
 		<div class="ep_citation_details">

--- a/static/style/auto/z_latest.css
+++ b/static/style/auto/z_latest.css
@@ -180,7 +180,7 @@ div.dropdown-content-table  table:hover {
 .ep_citation_tile_result_docs.ep_restricted_doc {
     background-image: url('/style/images/restricted2.png');
     background-size: 80%;
-    background-position: 25px -30px;
+    background-position: 25px;
     opacity: 0.5;
     border: none;
 }
@@ -196,9 +196,12 @@ div.dropdown-content-table  table:hover {
 .ep_citation_tile_result_docs.ep_public_doc {
     background-image: url('/style/images/default_image.png');
     background-size: 80%;
-    background-position: 25px -30px;
-    border: none; 
-    opacity: 0.5;
+    background-position: 25px;
+    border: none;
+    position: relative;
+    /* Set just the background opacity */
+    background-color: rgba(255, 255, 255, 0.5);
+    background-blend-mode: lighten;
 }
 .ep_citation_tile_result_link {
     display: block;

--- a/static/style/auto/z_search.css
+++ b/static/style/auto/z_search.css
@@ -94,8 +94,8 @@ margin-bottom: 5px;
 .ep_citation_tile_result_docs img 
 {
         width:100%;
-        height:100%
-        object-fit: cover; 
+        height:100%;
+        object-fit: contain; 
 }
 
 @media (max-width: 1276px) {


### PR DESCRIPTION
Because the `Latest Additions` section is trying to show 2 images (even though one of them will never be visible), the `+ {n} more...` below will always be one too few (https://github.com/eprints/eprints3.5/issues/182). This includes a couple of commits as I wasn't sure whether it should be changed visually.

The first commit (49006d4) just fixes the issue by reducing the number of images it tries to display and this would be mergeable on its own. The second commit (b9ed4d7) changes it so that the thumbnails are centered, contained and the default document icon is always centered in the background.

Before:
<img width="780" alt="Screenshot 2025-07-02 at 10 10 06 AM" src="https://github.com/user-attachments/assets/550930f4-3b2e-43a5-8a0a-1f6ade1258be" />
After:
<img width="782" alt="Screenshot 2025-07-02 at 10 09 44 AM" src="https://github.com/user-attachments/assets/f6e83e2d-d09f-41cb-b318-33842de0df5f" />