### PR TITLE
A couple of tweaks to thumbnail rendering

### DIFF
--- a/citations/eprint/latest_additions_result.xml
+++ b/citations/eprint/latest_additions_result.xml
@@ -7,11 +7,12 @@
 					<foreach expr="$docs" iterator="doc" limit="1">
 						<if test="$doc.is_public()">
 							<a href="{$item.uri()}">
-								<div class="ep_citation_tile_result_docs ep_public_doc">
-									<if test="is_set($doc.thumbnail_url('lightbox'))">
-										<img src="{$doc.thumbnail_url('lightbox')}" />
-									</if>
-								</div>
+								<if test="is_set($doc.thumbnail_url('lightbox'))">
+									<img src="{$doc.thumbnail_url('lightbox')}" />
+								</if>
+								<if test="!is_set($doc.thumbnail_url('lightbox'))">
+									<div class="ep_citation_tile_result_docs ep_public_doc" />
+								</if>
 							</a>
 						</if>
 						<if test="!$doc.is_public()">

--- a/citations/eprint/latest_additions_result.xml
+++ b/citations/eprint/latest_additions_result.xml
@@ -2,8 +2,8 @@
 <citation xmlns="http://www.w3.org/1999/xhtml" xmlns:cite="http://eprints.org/ep3/citation" xmlns:epc="http://eprints.org/ep3/control">
 	<div class="ep_search_result_block">
 		<set name="docs" expr="$item.documents()">
-			<if test="length($docs) gt 0">
-				<div class="ep_citation_tile_result_docs">
+			<div class="ep_citation_tile_result_docs">
+				<if test="length($docs) gt 0">
 					<foreach expr="$docs" iterator="doc" limit="1">
 						<if test="$doc.is_public()">
 							<a href="{$item.uri()}">
@@ -20,8 +20,11 @@
 							</a>
 						</if>
 					</foreach>
-				</div>
-			</if>
+				</if>
+				<if test="length($docs) lt 1">
+					<div class="ep_citation_tile_result_docs ep_citation_tile_result_metadata_only" />
+				</if>
+			</div>
 			<if test="length($docs) gt 1">
 				<div>
 					<a href="{$item.uri()}">
@@ -30,9 +33,6 @@
 						<phrase ref="page:more" />
 					</a>
 				</div>
-			</if>
-			<if test="length($docs) lt 1">
-				<div class="ep_citation_tile_result_docs ep_citation_tile_result_metadata_only" />
 			</if>
 		</set>
 		<div class="ep_citation_details">

--- a/static/style/auto/z_latest.css
+++ b/static/style/auto/z_latest.css
@@ -196,11 +196,8 @@ div.dropdown-content-table  table:hover {
     background-image: url('/style/images/default_image.png');
     background-size: 80%;
     background-position: 25px;
+    opacity: 0.5;
     border: none;
-    position: relative;
-    /* Set just the background opacity */
-    background-color: rgba(255, 255, 255, 0.5);
-    background-blend-mode: lighten;
 }
 .ep_citation_tile_result_link {
     display: block;

--- a/static/style/auto/z_latest.css
+++ b/static/style/auto/z_latest.css
@@ -188,8 +188,7 @@ div.dropdown-content-table  table:hover {
 .ep_citation_tile_result_docs.ep_citation_tile_result_metadata_only {
     background-image: url('/style/images/metadata-only.png');
     background-size: 80%;
-    background-position: 25px -30px;
-    margin-top: 15px;
+    background-position: 25px;
     opacity: 0.5;
     border: none;
 }


### PR DESCRIPTION
This adds a border to purely metadata items (fixes #9) and removes the e-page background from behind documents with thumbnails (fixes #10).