### PR TITLE
Allow the tile zoom on hover to be disabled in config

### DIFF
--- a/cfg.d/z_latest_tool.pl
+++ b/cfg.d/z_latest_tool.pl
@@ -30,6 +30,8 @@ $c->{latest_tool_feeds} = {
         RSS2 => { enabled => 1, "label" => "RSS 2.0" },
 };
 
+$c->{latest_tool_tile_zoom} = 1;
+
 =head1 COPYRIGHT
 
 =for COPYRIGHT BEGIN

--- a/cgi/z_latest_tool
+++ b/cgi/z_latest_tool
@@ -196,9 +196,16 @@ $page->appendChild( $container );
 my $n = 1;
 foreach my $item ( @records )
 {
+	# If 'latest_tool_tile_zoom' has been enabled (on by default) then we have
+	# to add the 'ep_citation_tile_zoom' class so that the CSS enables
+	my $zoom = $session->config( 'latest_tool_tile_zoom' );
+	my $tile_class = $zoom ? 'ep_citation_tile_zoom' : '';
+
 	my $row = $item->render_citation_link( 
 		$citation,
-		n => [$n++, "INTEGER"] );
+		n => [$n++, "INTEGER"],
+		tile_class => [$tile_class, 'STRING'],
+	);
 	if( $type eq "table_row" )
 	{
 		$container->appendChild( $row );

--- a/citations/eprint/latest_additions_result.xml
+++ b/citations/eprint/latest_additions_result.xml
@@ -2,7 +2,7 @@
 <citation xmlns="http://www.w3.org/1999/xhtml" xmlns:cite="http://eprints.org/ep3/citation" xmlns:epc="http://eprints.org/ep3/control">
 	<div class="ep_search_result_block">
 		<set name="docs" expr="$item.documents()">
-			<div class="ep_citation_tile_result_docs">
+			<div class="ep_citation_tile_result_docs {$tile_class}">
 				<if test="length($docs) gt 0">
 					<foreach expr="$docs" iterator="doc" limit="1">
 						<if test="$doc.is_public()">

--- a/static/style/auto/z_search.css
+++ b/static/style/auto/z_search.css
@@ -101,13 +101,13 @@ margin-bottom: 5px;
 }
 
 @media (min-width: 1276px) {
-    .ep_citation_tile_result_docs:hover img {
+    .ep_citation_tile_result_docs.ep_citation_tile_zoom:hover img {
         max-height: 230%;
     }
 }
 
 @media (min-width: 1067px) {
-    .ep_citation_tile_result_docs:hover img {
+    .ep_citation_tile_result_docs.ep_citation_tile_zoom:hover img {
         max-height: 310%;
     }
 }


### PR DESCRIPTION
Adds a config option `latest_tool_tile_zoom` which then gets passed through to the template and eventually HTML as the class `ep_citation_tile_zoom` which is used by the CSS to control whether or not it listens to `:hover` to zoom the images in.

It's potentially worth making this more general so that there is for example an option to fill the box entirely or center the image, which could be useful for repositories with a lot of images rather than a lot of PDFs where this default isn't necessarily the best.

Fixes #14.

#### This will need cherry-picking to the 3.4 branch